### PR TITLE
added cxx prefix

### DIFF
--- a/index.cxx
+++ b/index.cxx
@@ -1,5 +1,5 @@
 #include "index.hxx"
-#include "deps/datcxx/flat-tree/index.hxx"
+#include "deps/datcxx/cxx-flat-tree/index.hxx"
 
 namespace Hypercore {
   size_t getIndex () {


### PR DESCRIPTION
it looks like `#include "deps/datcxx/flat-tree/index.hxx"
` should be `#include "deps/datcxx/cxx-flat-tree/index.hxx"`